### PR TITLE
增加 DateEnd 配置属性

### DIFF
--- a/spider.go
+++ b/spider.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/elazarl/goproxy"
 )
@@ -76,10 +77,11 @@ var (
 )
 
 type Config struct {
-	Verbose     bool // Debug
-	AutoScroll  bool // Auto scroll page to hijack all history articles
-	Compress    bool // To ingore other request just to save the net cost
-	SleepSecond int  // Random seconds to sleep
+	Verbose     bool      // Debug
+	AutoScroll  bool      // Auto scroll page to hijack all history articles
+	Compress    bool      // To ingore other request just to save the net cost
+	SleepSecond int       // Random seconds to sleep
+	DateEnd     time.Time // The date of article which crawler will stop
 }
 
 func InitConfig(conf *Config) {


### PR DESCRIPTION
当爬虫爬行到指定日期时，自动停止。

以代替当前需爬行完整个公众号的文章列表后再执行`Processor.Output()` 方法。减少请求量以节约爬行时间。